### PR TITLE
Fixed the weird formatting of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-#Database Quotes JSON
-##JSON file with more than 5000+ famous quotes.
+# Database Quotes JSON
+## JSON file with more than 5000+ famous quotes.
 
-###Some example on how to work on this JSON quotes file
+### Some example on how to work on this JSON quotes file
 
-```javascript
+```js
 //return array of all quotes with 12 words max
 var filePath = "quotes.js";
 $.getJSON(filePath).done(function (data) {


### PR DESCRIPTION
You need to have a space between the # and the text inorder to make it a heading tag.
the syntax highlighting keyword should be `js` and not `javascript`.